### PR TITLE
Add navigation and initial views for Accounts and Balance

### DIFF
--- a/MisLukas/App.axaml
+++ b/MisLukas/App.axaml
@@ -1,5 +1,7 @@
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:MisLukas.ViewModels"
+             xmlns:views="clr-namespace:MisLukas.Views"
              x:Class="MisLukas.App"
              xmlns:local="using:MisLukas"
              RequestedThemeVariant="Default">
@@ -12,4 +14,5 @@
     <Application.Styles>
         <FluentTheme />
     </Application.Styles>
+             
 </Application>

--- a/MisLukas/App.axaml.cs
+++ b/MisLukas/App.axaml.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using Avalonia.Markup.Xaml;
 using Microsoft.Extensions.DependencyInjection;
 using MisLukas.Models;
-using MisLukas.Services;
 using MisLukas.ViewModels;
 using MisLukas.Views;
 
@@ -31,9 +30,11 @@ public partial class App : Application
 
         // ViewModels
         services.AddTransient<MainWindowViewModel>();
+        services.AddTransient<AccountViewModel>();
+        services.AddTransient<BalanceViewModel>();
 
         Services = services.BuildServiceProvider();
-        DbInitializer.Initialize();
+        //DbInitializer.Initialize();
 
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
@@ -46,7 +47,7 @@ public partial class App : Application
             };
             desktop.Exit += (sender, e) =>
             {
-                DbInitializer.Delete();
+                //DbInitializer.Delete();
             };
 
         }

--- a/MisLukas/MisLukas.csproj
+++ b/MisLukas/MisLukas.csproj
@@ -15,6 +15,7 @@
     <ItemGroup>
         <PackageReference Include="Avalonia" Version="11.1.0" />
         <PackageReference Include="Avalonia.Desktop" Version="11.1.0" />
+        <PackageReference Include="Avalonia.ReactiveUI" Version="11.1.0" />
         <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.0" />
         <PackageReference Include="Avalonia.Fonts.Inter" Version="11.1.0" />
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->

--- a/MisLukas/ViewModels/AccountViewModel.cs
+++ b/MisLukas/ViewModels/AccountViewModel.cs
@@ -1,0 +1,11 @@
+﻿namespace MisLukas.ViewModels;
+
+public class AccountViewModel : ViewModelBase
+{
+    public string Text { get; set; }
+
+    public AccountViewModel()
+    {
+        Text = "Account";
+    }
+}

--- a/MisLukas/ViewModels/BalanceViewModel.cs
+++ b/MisLukas/ViewModels/BalanceViewModel.cs
@@ -1,0 +1,11 @@
+﻿namespace MisLukas.ViewModels;
+
+public class BalanceViewModel : ViewModelBase
+{
+    public string Text { get; set; }
+    
+    public BalanceViewModel()
+    {
+        Text = "Balance General";
+    }
+}

--- a/MisLukas/ViewModels/MainWindowViewModel.cs
+++ b/MisLukas/ViewModels/MainWindowViewModel.cs
@@ -1,6 +1,30 @@
-﻿namespace MisLukas.ViewModels;
+﻿using System;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MisLukas.ViewModels;
 
 public partial class MainWindowViewModel : ViewModelBase
 {
-    public string Greeting { get; } = "Welcome to Avalonia!";
+    [ObservableProperty]
+    private ViewModelBase _currentPage;
+    
+    public MainWindowViewModel()
+    {
+        _currentPage = App.Services.GetRequiredService<AccountViewModel>();
+    }
+    
+    [RelayCommand]
+    public void NavigateToBalance()
+    {
+        CurrentPage = App.Services.GetRequiredService<BalanceViewModel>();
+        Console.WriteLine($"Navigate to {CurrentPage.GetType().Name}");
+    }
+    [RelayCommand]
+    public void NavigateToAccount()
+    {
+        CurrentPage = App.Services.GetRequiredService<AccountViewModel>();
+        Console.WriteLine($"Navigate to {CurrentPage.GetType().Name}");
+    }
 }

--- a/MisLukas/Views/Controls/AccountView.axaml
+++ b/MisLukas/Views/Controls/AccountView.axaml
@@ -1,0 +1,15 @@
+﻿<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:viewModels="clr-namespace:MisLukas.ViewModels"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="MisLukas.Views.AccountView"
+             x:DataType="viewModels:AccountViewModel">
+    
+    <Design.DataContext>
+        <viewModels:AccountViewModel/>
+    </Design.DataContext>
+    
+    <TextBlock Text="{Binding Text}"></TextBlock>
+</UserControl>

--- a/MisLukas/Views/Controls/AccountView.axaml.cs
+++ b/MisLukas/Views/Controls/AccountView.axaml.cs
@@ -1,0 +1,14 @@
+﻿using Avalonia.Controls;
+using Microsoft.Extensions.DependencyInjection;
+using MisLukas.ViewModels;
+
+namespace MisLukas.Views;
+
+public partial class AccountView : UserControl
+{
+    public AccountView()
+    {
+        DataContext = App.Services.GetRequiredService<AccountViewModel>();
+        InitializeComponent();
+    }
+}

--- a/MisLukas/Views/Controls/BalanceView.axaml
+++ b/MisLukas/Views/Controls/BalanceView.axaml
@@ -1,0 +1,15 @@
+﻿<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:viewModels="clr-namespace:MisLukas.ViewModels"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="MisLukas.Views.BalanceView"
+             x:DataType="viewModels:BalanceViewModel">
+    
+    <Design.DataContext>
+        <viewModels:BalanceViewModel/>
+    </Design.DataContext>
+    
+    <TextBlock Text="{Binding Text}"></TextBlock>
+</UserControl>

--- a/MisLukas/Views/Controls/BalanceView.axaml.cs
+++ b/MisLukas/Views/Controls/BalanceView.axaml.cs
@@ -1,0 +1,11 @@
+﻿using Avalonia.Controls;
+
+namespace MisLukas.Views;
+
+public partial class BalanceView : UserControl
+{
+    public BalanceView()
+    {
+        InitializeComponent();
+    }
+}

--- a/MisLukas/Views/Controls/NavigationMenu.axaml
+++ b/MisLukas/Views/Controls/NavigationMenu.axaml
@@ -1,0 +1,42 @@
+﻿<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:viewModels="clr-namespace:MisLukas.ViewModels"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="MisLukas.Views.NavigationMenu"
+             x:DataType="viewModels:MainWindowViewModel">
+    <Design.DataContext>
+        <viewModels:MainWindowViewModel/>
+    </Design.DataContext>
+    
+    <Border Background="#2C3E50" Padding="20">
+        <DockPanel LastChildFill="True">
+            
+            <StackPanel DockPanel.Dock="Top" Margin="0 0 0 20">
+                <TextBlock Text="FinanzasApp"
+                           Foreground="White"
+                           FontSize="20"
+                           FontWeight="Bold"
+                           HorizontalAlignment="Center"/>
+            </StackPanel>
+            
+            <StackPanel DockPanel.Dock="Bottom" Spacing="10">
+                <Button Content="Perfil" HorizontalAlignment="Stretch"/>
+                <Button Content="Configuración" HorizontalAlignment="Stretch"/>
+                <Button Content="Cambiar usuario" HorizontalAlignment="Stretch"/>
+            </StackPanel>
+            
+            <StackPanel Spacing="10">
+                <Button Content="Cuentas" HorizontalAlignment="Stretch" Command="{Binding NavigateToAccountCommand}"/>
+                <Button Content="Balance General" HorizontalAlignment="Stretch" Command="{Binding NavigateToBalanceCommand}"/>
+                <Button Content="Gastos" HorizontalAlignment="Stretch"/>
+                <Button Content="Ingresos" HorizontalAlignment="Stretch"/>
+                <Button Content="Deudas" HorizontalAlignment="Stretch"/>
+                <Button Content="Presupuestos" HorizontalAlignment="Stretch" />
+            </StackPanel>
+
+        </DockPanel>
+    </Border>
+    
+</UserControl>

--- a/MisLukas/Views/Controls/NavigationMenu.axaml.cs
+++ b/MisLukas/Views/Controls/NavigationMenu.axaml.cs
@@ -1,0 +1,11 @@
+﻿using Avalonia.Controls;
+
+namespace MisLukas.Views;
+
+public partial class NavigationMenu : UserControl
+{
+    public NavigationMenu()
+    {
+        InitializeComponent();
+    }
+}

--- a/MisLukas/Views/MainWindow.axaml
+++ b/MisLukas/Views/MainWindow.axaml
@@ -1,6 +1,7 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:MisLukas.ViewModels"
+        xmlns:cc="using:MisLukas.Views"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
@@ -10,17 +11,15 @@
         Title="MisLukas">
 
     <Design.DataContext>
-        <!-- This only sets the DataContext for the previewer in an IDE,
-             to set the actual DataContext for runtime, set the DataContext property in code (look at App.axaml.cs) -->
         <vm:MainWindowViewModel/>
     </Design.DataContext>
     
     <Grid ColumnDefinitions="0.3*,*">
-        <Grid Grid.Column="0" Background="AliceBlue">
-            <TextBlock>Menu</TextBlock>
+        <Grid Grid.Column="0">
+            <cc:NavigationMenu/>
         </Grid>
         <Grid Grid.Column="1">
-            <TextBlock>Body</TextBlock>
+            <ContentControl  Margin="30" Content="{Binding CurrentPage}"/>
         </Grid>
     </Grid>
 


### PR DESCRIPTION
Implemented `NavigationMenu` with commands for navigating between `AccountView` and `BalanceView`. Introduced `AccountViewModel` and `BalanceViewModel` to manage their respective views. Updated `MainWindowViewModel` to handle page navigation. Integrated required dependencies and adjusted application setup accordingly.